### PR TITLE
Sigsegv on incorrect input

### DIFF
--- a/src/main/java/com/arakelian/jq/JqRequest.java
+++ b/src/main/java/com/arakelian/jq/JqRequest.java
@@ -83,18 +83,15 @@ public abstract class JqRequest {
      * Adds any messages produced by jq native code it to the error store, with the provided prefix.
      *
      * @param value
-     * @param prefix
      */
     private String getInvalidMessage(final Jv value) {
         final Jv copy = getLib().jv_copy(value);
-        try {
-            if (getLib().jv_invalid_has_msg(copy)) {
-                final Jv message = getLib().jv_invalid_get_msg(value);
-                return getLib().jv_string_value(message);
-            }
-            return null;
-        } finally {
+        if (getLib().jv_invalid_has_msg(copy)) {
+            final Jv message = getLib().jv_invalid_get_msg(value);
+            return getLib().jv_string_value(message);
+        } else {
             getLib().jv_free(value);
+            return null;    
         }
     }
 
@@ -184,7 +181,7 @@ public abstract class JqRequest {
 
         // give text to JQ parser
         LOGGER.trace("Sending text to parser");
-        getLib().jv_parser_set_buf(parser, memory, input.length, false);
+        getLib().jv_parser_set_buf(parser, memory, input.length, true);
 
         final StringBuilder buf = new StringBuilder();
         for (;;) {
@@ -217,9 +214,6 @@ public abstract class JqRequest {
 
         // tell parser we are finished
         LOGGER.trace("Finishing with parser");
-        getLib().jv_parser_set_buf(parser, new Pointer(-1), 0, true);
-        final Jv parsed = getLib().jv_parser_next(parser);
-        isFinished(response, parsed);
 
         // finalize output
         final String output = buf.toString();

--- a/src/test/java/com/arakelian/jq/JqTest.java
+++ b/src/test/java/com/arakelian/jq/JqTest.java
@@ -158,4 +158,16 @@ public class JqTest {
                 "}", //
                 executeJq(request));
     }
+
+    @Test
+    public void testInvalidInput() {
+        final JqRequest request = ImmutableJqRequest.builder()
+                .lib(library)
+                .input("{{")
+                .filter(".")
+                .build();
+
+        JqResponse response = request.execute();
+        assertTrue(response.hasErrors());
+    }
 }


### PR DESCRIPTION
The test `testInvalidInput` introduced in first commit of this PR, without fix from second commit cases segfault on linux, but surprisingly works on mac os. (Tested on amd64, java8).

The second commit in this PR introduces a fix. The `value` in `getInvalidMessage` is "consumed" by `jv_invalid_get_msg`, so it is illegal to use it after this function, i.e. `jv_free` it in finally block. So we should `jv_free` it only if `getInvalidMessage` was for some reason called, when there is no message from libjq. 